### PR TITLE
Incremented the library version to pept-0.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pept" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: b044cc5b071d210816f9f7282b8330c17b3a624ff2bbc708b011ac06124663d3
+  sha256: 03efcab9245f1917e49db45d5d87e172e8dc219df0b02b4da0fb23f10cdf0cf9
 
 build:
   number: 0
@@ -17,19 +17,19 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - cython >=0.29.14
+    - cython >=0.29.13
     - numpy
     - pip
     - python
   run:
-    - cython >=0.29.14
+    - cython >=0.29.13
     - hdbscan >=0.8.26
-    - joblib >=0.15.1
-    - matplotlib-base >=3.2.2
+    - joblib >=0.13.2
+    - matplotlib-base >=3.1.1
     - {{ pin_compatible('numpy') }}
     - plotly >=4.4.1
     - python
-    - scipy >=1.4.1
+    - scipy >=1.3.1
     - six >=1.12.0
     - tqdm >=4.41.1
     - pandas >=1.0.5


### PR DESCRIPTION
Also lowered some minimum requirements to allow the use of the library on BlueBEAR, University of Birmingham supercomputing and HPC service.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
